### PR TITLE
Voices experimentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,11 +93,12 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -389,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8512c9117059663fb5606788fbca3619e2a91dac0e3fe516242eab1fa6be5e44"
 dependencies = [
  "alsa-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "nix",
 ]
@@ -38,11 +38,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -53,6 +53,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -60,6 +61,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block"
@@ -145,7 +152,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation 0.9.3",
  "core-graphics 0.21.0",
@@ -208,7 +215,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.7.0",
  "foreign-types",
  "libc",
@@ -220,7 +227,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.9.3",
  "foreign-types",
  "libc",
@@ -232,16 +239,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb17e2d1795b1996419648915df94bc7103c28f7b48062d7acf4652fc371b2ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation-sys 0.6.2",
  "coreaudio-sys",
 ]
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dff444d80630d7073077d38d40b4501fd518bd2b922c2a55edcc8b0f7be57e6"
+checksum = "d8478e5bdad14dce236b9898ea002eabfa87cbe14f0aa538dbe3b6a4bec4332d"
 dependencies = [
  "bindgen",
 ]
@@ -459,7 +466,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -488,7 +495,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
 ]
@@ -682,7 +689,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -770,7 +777,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f31d7fece546f1e6973011a9eceae948133bbd18fd3d52f6073b1e38ae6368a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "log",
  "symphonia-core",
@@ -784,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c73eb88fee79705268cc7b742c7bc93a7b76e092ab751d0833866970754142"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "lazy_static",
  "log",
@@ -828,6 +835,7 @@ dependencies = [
 name = "synth"
 version = "0.1.0"
 dependencies = [
+ "coreaudio-sys",
  "rdev",
  "rodio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2021"
 [dependencies]
 rdev = "0.5.3"
 rodio = "0.17.1"
+
+[[bin]]
+name = "synth"
+path = "src/main.rs"
+
+[[bin]]
+name = "bench"
+path = "src/bench.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 rdev = "0.5.3"
 rodio = "0.17.1"
+coreaudio-sys = "0.2.13"
 
 [[bin]]
 name = "synth"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,83 @@
+mod voices;
+
+use voices::voices::Voices;
+use voices::voices2::Voices2;
+use rdev::Key;
+use std::time::{Duration, SystemTime};
+
+fn main() {
+    let keys: Vec<Key> = vec![
+        Key::F1,
+        Key::F2,
+        Key::F3,
+        Key::F4,
+        Key::F5,
+        Key::F6,
+        Key::F7,
+        Key::F8,
+        Key::F9,
+        Key::F10,
+        Key::Num0,
+        Key::Num1,
+        Key::Num2,
+        Key::Num3,
+        Key::Num4,
+        Key::Num5,
+        Key::Num6,
+        Key::Num7,
+        Key::Num8,
+        Key::Num9,
+    ];
+
+    let mut test_data: Vec<Key> = vec![];
+
+    for _ in 0..100 {
+        for n in 0..10 {
+            for m in 0..4 {
+                for q in 0..3 {
+                    test_data.push(keys[n + m + q]);
+                }
+            }
+        }
+    }
+
+    let start = SystemTime::now();
+
+    for n in 0..10000 {
+        let mut voices:Voices<usize> = Voices::new(4);
+        let mut time = SystemTime::UNIX_EPOCH;
+    
+        for k in &test_data {
+            voices.play_with_time(*k, time, 0);
+
+            if n % 5 == 0 {
+                voices.stop(*k);
+            }
+
+            time = time.checked_add(Duration::new(1, 0)).unwrap();
+        }
+    }
+
+    let end = SystemTime::now();
+
+    println!("{:?}", end.duration_since(start));
+
+    let start = SystemTime::now();
+
+    for n in 0..10000 {
+        let mut voices2:Voices2<usize> = Voices2::new(4);
+    
+        for k in &test_data {
+            voices2.play(*k, 0);
+
+            if n % 5 == 0 {
+                voices2.stop(*k);
+            }
+        }
+    }
+
+    let end = SystemTime::now();
+
+    println!("{:?}", end.duration_since(start));
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use crate::oscilators::sine::SineWave;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_stream, stream_handle) = OutputStream::try_default()?;
     let num_voices = 4;
-    let mut voices = Voices::new(num_voices);
+    let mut voices: Voices<Sink> = Voices::new(num_voices);
 
     // This will block.
     if let Err(error) = listen(move |event| match event.event_type {
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         EventType::KeyRelease(key) => {
-            let removed = voices.stop(&key);
+            let removed = voices.stop(key);
             if removed.is_some() {
                 println!("Key released: {:?}, voices: {:?}", key, voices);
             }

--- a/src/voices/mod.rs
+++ b/src/voices/mod.rs
@@ -1,1 +1,2 @@
 pub mod voices;
+pub mod voices2;

--- a/src/voices/voices2.rs
+++ b/src/voices/voices2.rs
@@ -1,9 +1,9 @@
 use rdev::Key;
 
 fn get_ordinal(key: Key) -> u8 {
-    let ptr_to_option = (&key as *const Key) as *const u8;
+    let ptr_to_enum: *const u8 = (&key as *const Key) as *const u8;
     unsafe {
-        *ptr_to_option
+        *ptr_to_enum
     }
 }
 

--- a/src/voices/voices2.rs
+++ b/src/voices/voices2.rs
@@ -1,0 +1,52 @@
+use rdev::Key;
+
+fn get_ordinal(key: Key) -> u8 {
+    let ptr_to_option = (&key as *const Key) as *const u8;
+    unsafe {
+        *ptr_to_option
+    }
+}
+
+pub struct Voices2<T> {
+    in_order: Vec<(Key, T)>,
+    mask: u128
+}
+
+impl <T> Voices2<T> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            in_order: Vec::with_capacity(capacity),
+            mask: 0,
+        }
+    }
+
+    pub fn is_playing(&self, key: Key) -> bool {
+        let ord = get_ordinal(key);
+        self.mask & (1 << ord) != 0
+    }
+
+    pub fn play(&mut self, key: Key, sink: T) {
+        let ord = get_ordinal(key);
+        let bit = 1 << ord;
+        let playing = self.mask & bit != 0;
+        
+        if !playing {
+            if self.in_order.len() == self.in_order.capacity() {
+                self.in_order.remove(0);
+            }
+            self.in_order.push((key, sink));
+            self.mask |= bit;
+        }
+    }
+
+    pub fn stop(&mut self, key: Key) {
+        let ord = get_ordinal(key);
+        let bit = 1 << ord;
+        let playing = self.mask & bit != 0;
+
+        if playing {
+            self.in_order.retain(|(k,_)| !matches!(*k, key));
+            self.mask &= !bit;
+        }
+    }
+}


### PR DESCRIPTION
* Cargo.toml hacked so we can have two main() entry points, one `bench` for crude benchmarking
* Some changes made to `Voices`, making it generic (needed in earlier testing, probably no longer needed). Note passing Key enums by value is cheap, we don't need references.
* `Voices2` is where the action is
* `bench.rs` contains the simple benchmark, for better or worse
* The code can pack the key ordinal into a `u128` as there are fewer than 128 keys. If that were not the case it'll blow up.

This code isn't polished and is meant to inspire ideas.

Note we can derive an enum ordinal using a crate, but `Key` was defined in a dependency so we can't, hence the hack with 🤭 unsafe.